### PR TITLE
Update init.d template for redhat distribution

### DIFF
--- a/templates/etc/init/mailcatcher.sysv.erb
+++ b/templates/etc/init/mailcatcher.sysv.erb
@@ -11,7 +11,7 @@
 PID=""
 
 updatepid(){
-   PID=$(ps aux|grep "ruby <%= @mailcatcher_path %>/[m]ailcatcher" |awk '{print $2}')
+   PID=$(ps aux|grep -E "ruby(-.*)* <%= @mailcatcher_path %>/[m]ailcatcher" |awk '{print $2}')
 }
 
 start(){


### PR DESCRIPTION
- allow other ruby packages like ruby-mri in fedora
- update template to use custom mailcatcher_path
