### PR TITLE
Fix mailcatcher path in init scripts

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ class mailcatcher::config  {
     shell            => '/bin/true',
   }
 
+  $mailcatcher_path = $mailcatcher::params::mailcatcher_path
   $options = sort(join_keys_to_values({' --smtp-ip'   => $mailcatcher::smtp_ip,
                                   ' --smtp-port' => $mailcatcher::smtp_port,
                                   ' --http-ip'   => $mailcatcher::http_ip,


### PR DESCRIPTION
The Mailcatcher path was not passed through to the init script templates thus ended up as `/mailcatcher`.

Fixes #18, #19