### PR TITLE
Fixing CentOS6 again.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # class mailcatcher::config
 #
-class mailcatcher::config  {
+class mailcatcher::config {
   user { 'mailcatcher':
     ensure  => 'present',
     comment => 'Mailcatcher Mock Smtp Service User',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@
 #   The default is false
 #
 # [*version*]
-#   Install this specific version of mailcatcher.
+#   Specify a specific version of mailcatcher to install.
 #   The default is latest
 #
 # === Examples

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,8 +30,12 @@
 #   The default is '/usr/local/bin'
 #
 # [*service_enable*]
-#   Enable Service at boot
+#   Enable Service at boot.
 #   The default is false
+#
+# [*version*]
+#   Install this specific version of mailcatcher.
+#   The default is latest
 #
 # === Examples
 #
@@ -51,7 +55,7 @@
 #
 # === Copyright
 #
-# Copyright 2013 Martin Jackson, unless otherwise noted.
+# Copyright 2013-2015 Martin Jackson, unless otherwise noted.
 #
 # Todo
 # - Only supports debian based distros need support for other distros
@@ -64,6 +68,7 @@ class mailcatcher (
   $http_port        = $mailcatcher::params::http_port,
   $mailcatcher_path = $mailcatcher::params::mailcatcher_path,
   $service_enable   = $mailcatcher::params::service_enable,
+  $version          = $mailcatcher::params::version,
 ) inherits mailcatcher::params {
 
   class {'mailcatcher::package': } ->

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -8,8 +8,29 @@ class mailcatcher::package {
     ensure => 'present'
   } ->
   package { 'mailcatcher':
-    ensure   => 'present',
+    ensure   => $mailcatcher::version,
     provider => 'gem',
     require  => Class['ruby::dev'],
+  }
+
+
+
+  # Needed for CentOS6 backport of older mailcatcher version.
+  # See params.pp for more information.
+  if ($mailcatcher::params::fixeventmachineversion) {
+    package { 'eventmachine':
+      ensure   => $mailcatcher::params::fixeventmachineversion,
+      provider => 'gem',
+      require  => Class['ruby::dev'],
+      before   => Package['mailcatcher'],
+    }
+  }
+  if ($mailcatcher::params::fixi18nversion) {
+    package { 'i18n':
+      ensure   => $mailcatcher::params::fixi18nversion,
+      provider => 'gem',
+      require  => Class['ruby::dev'],
+      before   => Package['mailcatcher'],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,42 +6,56 @@ class mailcatcher::params {
   $http_ip          = '0.0.0.0'
   $http_port        = '1080'
   $service_enable   = false
+  $default_version  = 'latest'
 
   case $::osfamily {
     'Debian': {
-      $packages = ['sqlite3', 'libsqlite3-dev']
+      $version          = $default_version
+      $packages         = ['sqlite3', 'libsqlite3-dev']
       $mailcatcher_path = '/usr/local/bin'
 
       case $::operatingsystem {
         'Ubuntu': {
           $config_file = '/etc/init/mailcatcher.conf'
-          $template = 'mailcatcher/etc/init/mailcatcher.conf.erb'
-          $provider = 'upstart'
+          $template    = 'mailcatcher/etc/init/mailcatcher.conf.erb'
+          $provider    = 'upstart'
         }
         default: {
           $config_file = '/etc/init.d/mailcatcher'
           $template    = 'mailcatcher/etc/init/mailcatcher.lsb.erb'
-          $provider = 'debian'
+          $provider    = 'debian'
         }
       }
     }
+    # RHEL, CentOS
     'Redhat': {
-    # rubygem-mime-types from gem requires ruby >= 1.9.2 which is not available on CentOS6, in CentOS7 the gem installed mime-types causes  "Encoding::CompatibilityError", so use the package from EPEL which just works fine for CentOS 6 and 7.
-    # multi_json from gem causes a crash when receiving a mail: /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:54:in `require': Did not recognize your adapter specification (cannot load such file -- json/ext/parser). (MultiJson::AdapterError)
-      $std_packages = ['sqlite-devel', 'gcc-c++', 'rubygem-mime-types', 'rubygem-multi_json']
-      $config_file = '/etc/init.d/mailcatcher'
-      $template = 'mailcatcher/etc/init/mailcatcher.sysv.erb'
-      $provider = 'redhat'
+      # rubygem-mime-types from gem requires ruby >= 1.9.2 which is not available on CentOS6, in CentOS7 the gem installed mime-types causes "Encoding::CompatibilityError", so use the package from EPEL which just works fine for CentOS 6 and 7.
+      $std_packages = ['sqlite-devel', 'gcc-c++', 'rubygem-mime-types']
+      $config_file  = '/etc/init.d/mailcatcher'
+      $template     = 'mailcatcher/etc/init/mailcatcher.sysv.erb'
+      $provider     = 'redhat'
 
+      # We need to distinguish between major RHEL release versions
       case $::operatingsystemmajrelease {
         7: {
           $mailcatcher_path = '/usr/local/bin'
           # json_pure is a runtime requirement which does not get installed with mailcatcher 0.5.12
-          $packages = union($std_packages, ['rubygem-json_pure'])
+          # multi_json from gem causes a crash when receiving a mail: /usr/local/share/ruby/site_ruby/rubygems/core_ext/kernel_require.rb:54:in `require': Did not recognize your adapter specification (cannot load such file -- json/ext/parser). (MultiJson::AdapterError)
+          $packages = union($std_packages, ['rubygem-json_pure', 'rubygem-multi_json'])
+          $version = $default_version
         }
-        default: {
+        6: {
           $mailcatcher_path = '/usr/bin'
           $packages = $std_packages
+          # newer mailcatcher versions require gems which require i18n gem which is not compatible with CentOS6's ruby version 1.8.7
+          # https://github.com/sj26/mailcatcher/issues/213
+          $version = '0.5.12'
+          # last version of i18n gem which worked with CentOS6's ruby version
+          $fixi18nversion = '0.6.11'
+          # newer versions do not accept mails with mailcatcher in background, mailcatcher in foreground works
+          # Fixed in mailcatcher 0.6.1, but that one is incompatible with CentOS6
+          # https://github.com/sj26/mailcatcher/issues/182
+          $fixeventmachineversion = '1.0.3'
         }
       }
     }


### PR DESCRIPTION
This gets really messy, but newer versions of mailcatcher have dependencies on
gems which depend on gems that are not compatible with CentOS6's ruby version
1.8.7 anymore. To get a working mailcatcher on CentOS6 I need to stick with
an older mailcatcher 0.5.12. This requires a specific compatible i18n gem and
a specific eventmachine gem, as newer version do not accept mails in background
mode anymore. This is fixed in current mailcatcher version, but that one is
not compatible because of the other dependencies. WTF :-!