### PR TITLE
CentOS 7 isn't detected using Puppet 3.7.4. Major version in quotes help...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class mailcatcher::params {
       $provider = 'redhat'
 
       case $::operatingsystemmajrelease {
-        7: {
+        '7': {
           $mailcatcher_path = '/usr/local/bin'
           # json_pure is a runtime requirement which does not get installed with mailcatcher 0.5.12
           $packages = union($std_packages, ['rubygem-json_pure'])


### PR DESCRIPTION
Fix of #23  

CentOS 7 version is not detected correctly. Mailcatcher is installed in /usr/local/bin/mailcatcher, but in service scripts there is path /usr/bin/mailcatcher. 