### PR TITLE
Do not require the package directly, prefer the Puppetlabs GCC module

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,3 +10,4 @@ project_page 'https://github.com/actionjack/puppet-mailcatcher'
 
 dependency 'puppetlabs/stdlib', '>= 4.2.0'
 dependency 'puppetlabs/ruby', '>= 0.3.0'
+dependency 'puppetlabs/gcc', '>= 0.3.0'

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -3,6 +3,7 @@
 class mailcatcher::package {
   include ruby
   include ruby::dev
+  include gcc
 
   package { $mailcatcher::params::packages :
     ensure => 'present'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class mailcatcher::params {
     # RHEL/CentOS
     'Redhat': {
       # rubygem-mime-types from gem requires ruby >= 1.9.2 which is not available on CentOS6, in CentOS7 the gem installed mime-types causes "Encoding::CompatibilityError", so use the package from EPEL which just works fine for CentOS 6 and 7.
-      $std_packages = ['sqlite-devel', 'gcc-c++', 'rubygem-mime-types']
+      $std_packages = ['sqlite-devel', 'rubygem-mime-types']
       $config_file  = '/etc/init.d/mailcatcher'
       $template     = 'mailcatcher/etc/init/mailcatcher.sysv.erb'
       $provider     = 'redhat'


### PR DESCRIPTION
This prevents duplicate declarations of the gcc++ package, by including the module only once.