### PR TITLE
Fix EL6 test for Puppet >=4.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class mailcatcher::params {
           $packages = union($std_packages, ['rubygem-json_pure', 'rubygem-multi_json'])
           $version  = $default_version
         }
-        6: {
+        '6': {
           $mailcatcher_path = '/usr/bin'
           $packages = $std_packages
           # newer mailcatcher versions require gems which require i18n gem which is not compatible with CentOS6's ruby version 1.8.7


### PR DESCRIPTION
operatingsystemmajrelease returns a String, not a Number - this check fails with Puppet 4's strict type comparisons.

Verified with Puppet 4/CentOS6. Untested on earlier Puppet versions.