### PR TITLE
Add dependency on puppetlabs/gcc to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" },
-    { "name": "puppetlabs/firewall", "version_requirement": ">= 0.0.4" }
+    { "name": "puppetlabs/firewall", "version_requirement": ">= 0.0.4" },
+    { "name": "puppetlabs/gcc", "version_requirement": ">= 0.3.0" }
   ]
 }


### PR DESCRIPTION
This was in Modulefile, but not in metadata.json
