### PR TITLE
activesupport in Debian

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -15,6 +15,17 @@ class mailcatcher::package {
   }
 
 
+  # Needed vor Debian
+  # See params.pp for more information
+  if ($mailcatcher::params::fixactivesupportversion) {
+    package { 'activesupport':
+      ensure   => $mailcatcher::params::fixactivesupportversion,
+      provider => 'gem',
+      require  => Class['ruby::dev'],
+      before   => Package['mailcatcher'],
+    }
+  }
+
 
   # Needed for CentOS6 backport of older mailcatcher version.
   # See params.pp for more information.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,8 @@ class mailcatcher::params {
           $config_file = '/etc/init.d/mailcatcher'
           $template    = 'mailcatcher/etc/init/mailcatcher.lsb.erb'
           $provider    = 'debian'
+          # mailcatcher requires activesupport and pulls in Version 5.0.0.beta1 in debian which requires ruby 2.2.2 which is not available
+          $fixactivesupportversion = '4.2.5'
         }
       }
     }


### PR DESCRIPTION
mailcatcher requires activesupport and pulls in 5.0.0.beta1 which requires ruby 2.2.2 which is not available. Set activesuport version to 4.2.5 fixes install of mailcatcher under Debian.
